### PR TITLE
ensure that the subtree is also considered when getting accessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "XspecT"
-version = "0.5.2"
+version = "0.5.3"
 description = "Tool to monitor and characterize pathogens using Bloom filters."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/xspect/main.py
+++ b/src/xspect/main.py
@@ -49,7 +49,9 @@ def models():
 def download():
     """Download models."""
     click.echo("Downloading models, this may take a while...")
-    download_test_models("http://assets.adrianromberg.com/ake/xspect-models.zip")
+    download_test_models(
+        "https://assets.adrianromberg.com/science/xspect-models-07-08-2025.zip"
+    )
 
 
 @models.command(

--- a/src/xspect/ncbi.py
+++ b/src/xspect/ncbi.py
@@ -221,6 +221,7 @@ class NCBIHandler:
         """
         endpoint = (
             f"/genome/taxon/{taxon_id}/dataset_report?"
+            f"filters.tax_exact_match=false&"
             f"filters.assembly_source={assembly_source.value}&"
             f"filters.exclude_atypical={exclude_atypical}&"
             f"filters.exclude_paired_reports={exclude_paired_reports}&"
@@ -228,9 +229,9 @@ class NCBIHandler:
             f"page_size={count * 2}&"  # to avoid having less than count if n50 or ANI is not met
         )
         endpoint += (
-            "&filters.reference_only=true"
+            "filters.reference_only=true&"
             if assembly_level == AssemblyLevel.REFERENCE
-            else f"&filters.assembly_level={assembly_level.value}"
+            else f"filters.assembly_level={assembly_level.value}"
         )
 
         response = self._make_request(endpoint)

--- a/src/xspect/web.py
+++ b/src/xspect/web.py
@@ -31,7 +31,9 @@ def root():
 @router.get("/download-filters")
 def download_filters():
     """Download filters."""
-    download_test_models("http://assets.adrianromberg.com/xspect-models.zip")
+    download_test_models(
+        "https://assets.adrianromberg.com/science/xspect-models-07-08-2025.zip"
+    )
 
 
 @router.get("/classification-result")


### PR DESCRIPTION
Accessions belonging to a species may sometimes have a different taxonomy ID on NCBI, as they belong to the subtree. For example, the _Acinetobacter pittii_ reference genome has a different taxonomy ID than _A. pittii_, as it has a strain-specific taxonomy ID. The fix ensures that the subtree is always considered when looking for genome accessions.