### PR TITLE
Display name next to taxonomic ID

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -114,6 +114,14 @@ xspect classify species --sparse-sampling-step 10 Acinetobacter path
 
 This will only consider every 10th kmer in the sample.
 
+### Inclusion of display names
+By default, the classification results show only the taxonomy ID of each species along with its corresponding score for better readability. To display the full names associated with each taxonomy ID, you can use the `--display-names` (or `-n`) option:
+
+```bash
+xspect classify species --display-names Acinetobacter path
+```
+The output will then be formatted as: `Taxonomy_ID - Display_Name: Score` for each species.
+
 ### MLST Classification
 
 Samples can also be classified based on Multi-locus sequence type schemas. To MLST-classify a sample, run:

--- a/src/xspect/classify.py
+++ b/src/xspect/classify.py
@@ -41,7 +41,11 @@ def classify_genus(
 
 
 def classify_species(
-    model_genus: str, input_path: Path, output_path: Path, step: int = 1
+    model_genus: str,
+    input_path: Path,
+    output_path: Path,
+    step: int = 1,
+    scientific: bool = False,
 ):
     """
     Classify the species of sequences.
@@ -54,6 +58,7 @@ def classify_species(
         input_path (Path): The path to the input file/directory containing sequences.
         output_path (Path): The path to the output file where results will be saved.
         step (int): The amount of kmers to be skipped.
+        scientific (bool): Includes scientific names for each tax_ID.
     """
     ProbabilisticFilterSVMModel = import_module(
         "xspect.models.probabilistic_filter_svm_model"
@@ -64,7 +69,7 @@ def classify_species(
     input_paths, get_output_path = prepare_input_output_paths(input_path)
 
     for idx, current_path in enumerate(input_paths):
-        result = model.predict(current_path, step=step)
+        result = model.predict(current_path, step=step, scientific=scientific)
         result.input_source = current_path.name
         cls_path = get_output_path(idx, output_path)
         result.save(cls_path)

--- a/src/xspect/classify.py
+++ b/src/xspect/classify.py
@@ -45,7 +45,7 @@ def classify_species(
     input_path: Path,
     output_path: Path,
     step: int = 1,
-    scientific: bool = False,
+    display_name: bool = False,
 ):
     """
     Classify the species of sequences.
@@ -58,7 +58,7 @@ def classify_species(
         input_path (Path): The path to the input file/directory containing sequences.
         output_path (Path): The path to the output file where results will be saved.
         step (int): The amount of kmers to be skipped.
-        scientific (bool): Includes scientific names for each tax_ID.
+        display_name (bool): Includes a display name for each tax_ID.
     """
     ProbabilisticFilterSVMModel = import_module(
         "xspect.models.probabilistic_filter_svm_model"
@@ -69,7 +69,7 @@ def classify_species(
     input_paths, get_output_path = prepare_input_output_paths(input_path)
 
     for idx, current_path in enumerate(input_paths):
-        result = model.predict(current_path, step=step, scientific=scientific)
+        result = model.predict(current_path, step=step, display_name=display_name)
         result.input_source = current_path.name
         cls_path = get_output_path(idx, output_path)
         result.save(cls_path)

--- a/src/xspect/main.py
+++ b/src/xspect/main.py
@@ -281,13 +281,25 @@ def classify_genus(model_genus, input_path, output_path, sparse_sampling_step):
     help="Sparse sampling step (e. g. only every 500th kmer for '--sparse-sampling-step 500').",
     default=1,
 )
-def classify_species(model_genus, input_path, output_path, sparse_sampling_step):
+@click.option(
+    "-s",
+    "--scientific-name",
+    help="Includes the scientific name next to the taxonomy-ID.",
+    is_flag=True,
+)
+def classify_species(
+    model_genus, input_path, output_path, sparse_sampling_step, scientific_name
+):
     """Classify samples using a species model."""
     click.echo("Classifying...")
     classify = import_module("xspect.classify")
 
     classify.classify_species(
-        model_genus, Path(input_path), Path(output_path), sparse_sampling_step
+        model_genus,
+        Path(input_path),
+        Path(output_path),
+        sparse_sampling_step,
+        scientific_name,
     )
 
 

--- a/src/xspect/main.py
+++ b/src/xspect/main.py
@@ -282,13 +282,13 @@ def classify_genus(model_genus, input_path, output_path, sparse_sampling_step):
     default=1,
 )
 @click.option(
-    "-s",
-    "--scientific-name",
-    help="Includes the scientific name next to the taxonomy-ID.",
+    "-n",
+    "--display-names",
+    help="Includes the display names next to taxonomy-IDs.",
     is_flag=True,
 )
 def classify_species(
-    model_genus, input_path, output_path, sparse_sampling_step, scientific_name
+    model_genus, input_path, output_path, sparse_sampling_step, display_names
 ):
     """Classify samples using a species model."""
     click.echo("Classifying...")
@@ -299,7 +299,7 @@ def classify_species(
         Path(input_path),
         Path(output_path),
         sparse_sampling_step,
-        scientific_name,
+        display_names,
     )
 
 

--- a/src/xspect/models/probabilistic_filter_model.py
+++ b/src/xspect/models/probabilistic_filter_model.py
@@ -230,6 +230,7 @@ class ProbabilisticFilterModel:
         ),
         filter_ids: list[str] = None,
         step: int = 1,
+        scientific: bool = False,
     ) -> ModelResult:
         """
         Returns a model result object for the sequence(s) based on the filters in the model
@@ -246,6 +247,7 @@ class ProbabilisticFilterModel:
             filter_ids (list[str]): A list of filter IDs to filter the results. If None,
                 all results are returned.
             step (int): The step size for the k-mer search. Default is 1.
+            scientific (bool): Includes scientific names for each tax_ID.
 
         Returns:
             ModelResult: An object containing the hits for each sequence, the number of kmers,
@@ -258,7 +260,7 @@ class ProbabilisticFilterModel:
         """
         if isinstance(sequence_input, (SeqRecord)):
             return ProbabilisticFilterModel.predict(
-                self, [sequence_input], filter_ids, step=step
+                self, [sequence_input], filter_ids, step=step, scientific=scientific
             )
 
         if self._is_sequence_list(sequence_input) | self._is_sequence_iterator(
@@ -273,12 +275,25 @@ class ProbabilisticFilterModel:
                 num_kmers[individual_sequence.id] = self._count_kmers(
                     individual_sequence, step=step
                 )
+                if scientific:
+                    individual_hits.update(
+                        {
+                            f"{key} -{self.display_names.get(key, 'Unknown').replace( 
+                                self.model_display_name, '', 1)}": individual_hits.pop(
+                                key
+                            )
+                            for key in list(individual_hits.keys())
+                        }
+                    )
                 hits[individual_sequence.id] = individual_hits
             return ModelResult(self.slug(), hits, num_kmers, sparse_sampling_step=step)
 
         if isinstance(sequence_input, Path):
             return ProbabilisticFilterModel.predict(
-                self, get_record_iterator(sequence_input), step=step
+                self,
+                get_record_iterator(sequence_input),
+                step=step,
+                scientific=scientific,
             )
 
         raise ValueError(

--- a/src/xspect/models/probabilistic_filter_model.py
+++ b/src/xspect/models/probabilistic_filter_model.py
@@ -230,7 +230,7 @@ class ProbabilisticFilterModel:
         ),
         filter_ids: list[str] = None,
         step: int = 1,
-        scientific: bool = False,
+        display_name: bool = False,
     ) -> ModelResult:
         """
         Returns a model result object for the sequence(s) based on the filters in the model
@@ -247,7 +247,7 @@ class ProbabilisticFilterModel:
             filter_ids (list[str]): A list of filter IDs to filter the results. If None,
                 all results are returned.
             step (int): The step size for the k-mer search. Default is 1.
-            scientific (bool): Includes scientific names for each tax_ID.
+            display_name (bool): Includes a display name for each tax_ID.
 
         Returns:
             ModelResult: An object containing the hits for each sequence, the number of kmers,
@@ -260,7 +260,7 @@ class ProbabilisticFilterModel:
         """
         if isinstance(sequence_input, (SeqRecord)):
             return ProbabilisticFilterModel.predict(
-                self, [sequence_input], filter_ids, step=step, scientific=scientific
+                self, [sequence_input], filter_ids, step=step, display_name=display_name
             )
 
         if self._is_sequence_list(sequence_input) | self._is_sequence_iterator(
@@ -275,7 +275,7 @@ class ProbabilisticFilterModel:
                 num_kmers[individual_sequence.id] = self._count_kmers(
                     individual_sequence, step=step
                 )
-                if scientific:
+                if display_name:
                     individual_hits.update(
                         {
                             f"{key} -{self.display_names.get(key, 'Unknown').replace( 
@@ -293,7 +293,7 @@ class ProbabilisticFilterModel:
                 self,
                 get_record_iterator(sequence_input),
                 step=step,
-                scientific=scientific,
+                display_name=display_name,
             )
 
         raise ValueError(

--- a/src/xspect/models/probabilistic_filter_svm_model.py
+++ b/src/xspect/models/probabilistic_filter_svm_model.py
@@ -183,7 +183,7 @@ class ProbabilisticFilterSVMModel(ProbabilisticFilterModel):
         ),
         filter_ids: list[str] = None,
         step: int = 1,
-        scientific: bool = False,
+        display_name: bool = False,
     ) -> ModelResult:
         """
         Predict the labels of the sequences.
@@ -197,14 +197,14 @@ class ProbabilisticFilterSVMModel(ProbabilisticFilterModel):
             SeqIO.QualityIO.FastqPhredIterator | Path): The input sequences to predict.
             filter_ids (list[str], optional): A list of IDs to filter the predictions.
             step (int, optional): Step size for sparse sampling. Defaults to 1.
-            scientific (bool): Includes scientific names for each tax_ID.
+            display_name (bool): Includes a display name for each tax_ID.
 
         Returns:
             ModelResult: The result of the prediction containing hits, number of kmers, and the
             predicted label.
         """
         # get scores and format them for the SVM
-        res = super().predict(sequence_input, filter_ids, step, scientific)
+        res = super().predict(sequence_input, filter_ids, step, display_name)
         svm_scores = dict(sorted(res.get_scores()["total"].items()))
         svm_scores = [list(svm_scores.values())]
 

--- a/src/xspect/models/probabilistic_filter_svm_model.py
+++ b/src/xspect/models/probabilistic_filter_svm_model.py
@@ -183,6 +183,7 @@ class ProbabilisticFilterSVMModel(ProbabilisticFilterModel):
         ),
         filter_ids: list[str] = None,
         step: int = 1,
+        scientific: bool = False,
     ) -> ModelResult:
         """
         Predict the labels of the sequences.
@@ -196,13 +197,14 @@ class ProbabilisticFilterSVMModel(ProbabilisticFilterModel):
             SeqIO.QualityIO.FastqPhredIterator | Path): The input sequences to predict.
             filter_ids (list[str], optional): A list of IDs to filter the predictions.
             step (int, optional): Step size for sparse sampling. Defaults to 1.
+            scientific (bool): Includes scientific names for each tax_ID.
 
         Returns:
             ModelResult: The result of the prediction containing hits, number of kmers, and the
             predicted label.
         """
         # get scores and format them for the SVM
-        res = super().predict(sequence_input, filter_ids, step=step)
+        res = super().predict(sequence_input, filter_ids, step, scientific)
         svm_scores = dict(sorted(res.get_scores()["total"].items()))
         svm_scores = [list(svm_scores.values())]
 


### PR DESCRIPTION
Added an option that includes display names next to taxonomic IDs in the resulting JSON file.
To run this option an additional parameter "-n" or "--display-names" has to be provided, when using the species classification.

Additionally, a small update to the documentation has been made, that adresses the newly added parameter.