### PR TITLE
- Added a feature that detects misclassified reads.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,10 @@ dependencies = [
   "xxhash",
   "fastapi",
   "uvicorn",
-  "python-multipart"
+  "python-multipart",
+  "mappy",
+  "pysam",
+  "numpy"
   ]
 classifiers = [
   "Intended Audience :: Developers",

--- a/src/xspect/classify.py
+++ b/src/xspect/classify.py
@@ -46,6 +46,7 @@ def classify_species(
     output_path: Path,
     step: int = 1,
     display_name: bool = False,
+    short_read_mode: bool = False,
 ):
     """
     Classify the species of sequences.
@@ -59,6 +60,7 @@ def classify_species(
         output_path (Path): The path to the output file where results will be saved.
         step (int): The amount of kmers to be skipped.
         display_name (bool): Includes a display name for each tax_ID.
+        short_read_mode (bool): Sorts out misclassified reads.
     """
     ProbabilisticFilterSVMModel = import_module(
         "xspect.models.probabilistic_filter_svm_model"
@@ -69,7 +71,12 @@ def classify_species(
     input_paths, get_output_path = prepare_input_output_paths(input_path)
 
     for idx, current_path in enumerate(input_paths):
-        result = model.predict(current_path, step=step, display_name=display_name)
+        result = model.predict(
+            current_path,
+            step=step,
+            display_name=display_name,
+            short_read_mode=short_read_mode,
+        )
         result.input_source = current_path.name
         cls_path = get_output_path(idx, output_path)
         result.save(cls_path)

--- a/src/xspect/classify.py
+++ b/src/xspect/classify.py
@@ -46,7 +46,7 @@ def classify_species(
     output_path: Path,
     step: int = 1,
     display_name: bool = False,
-    short_read_mode: bool = False,
+    validation: bool = False,
 ):
     """
     Classify the species of sequences.
@@ -60,7 +60,7 @@ def classify_species(
         output_path (Path): The path to the output file where results will be saved.
         step (int): The amount of kmers to be skipped.
         display_name (bool): Includes a display name for each tax_ID.
-        short_read_mode (bool): Sorts out misclassified reads.
+        validation (bool): Sorts out misclassified reads.
     """
     ProbabilisticFilterSVMModel = import_module(
         "xspect.models.probabilistic_filter_svm_model"
@@ -75,7 +75,7 @@ def classify_species(
             current_path,
             step=step,
             display_name=display_name,
-            short_read_mode=short_read_mode,
+            validation=validation,
         )
         result.input_source = current_path.name
         cls_path = get_output_path(idx, output_path)

--- a/src/xspect/definitions.py
+++ b/src/xspect/definitions.py
@@ -89,3 +89,22 @@ def get_xspect_mlst_path() -> Path:
     mlst_path = get_xspect_root_path() / "mlst"
     mlst_path.mkdir(exist_ok=True, parents=True)
     return mlst_path
+
+
+def get_xspect_misclassification_path() -> Path:
+    """
+    Notes:
+    Developed by Oemer Cetin as part of a Bsc thesis at Goethe University Frankfurt am Main (2025).
+    (An Integration of Alignment-Free and Alignment-Based Approaches for Bacterial Taxon Assignment)
+
+    Return the path to the XspecT Misclassification directory.
+
+    Returns the path to the XspecT Misclassification directory, which is located within the XspecT data
+    directory. If the directory does not exist, it creates the directory.
+
+    Returns:
+        Path: The path to the XspecT Misclassification directory.
+    """
+    misclassification_path = get_xspect_root_path() / "misclassification"
+    misclassification_path.mkdir(exist_ok=True, parents=True)
+    return misclassification_path

--- a/src/xspect/main.py
+++ b/src/xspect/main.py
@@ -287,8 +287,19 @@ def classify_genus(model_genus, input_path, output_path, sparse_sampling_step):
     help="Includes the display names next to taxonomy-IDs.",
     is_flag=True,
 )
+@click.option(
+    "-r",
+    "--short-read-mode",
+    help="Detects misclassification for small reads or contigs.",
+    is_flag=True,
+)
 def classify_species(
-    model_genus, input_path, output_path, sparse_sampling_step, display_names
+    model_genus,
+    input_path,
+    output_path,
+    sparse_sampling_step,
+    display_names,
+    short_read_mode,
 ):
     """Classify samples using a species model."""
     click.echo("Classifying...")
@@ -300,6 +311,7 @@ def classify_species(
         Path(output_path),
         sparse_sampling_step,
         display_names,
+        short_read_mode,
     )
 
 

--- a/src/xspect/main.py
+++ b/src/xspect/main.py
@@ -289,7 +289,7 @@ def classify_genus(model_genus, input_path, output_path, sparse_sampling_step):
 )
 @click.option(
     "-v",
-    "--mapping-based-validation",
+    "--validation",
     help="Detects misclassification for small reads or contigs.",
     is_flag=True,
 )

--- a/src/xspect/main.py
+++ b/src/xspect/main.py
@@ -288,8 +288,8 @@ def classify_genus(model_genus, input_path, output_path, sparse_sampling_step):
     is_flag=True,
 )
 @click.option(
-    "-r",
-    "--short-read-mode",
+    "-v",
+    "--mapping-based-validation",
     help="Detects misclassification for small reads or contigs.",
     is_flag=True,
 )
@@ -299,7 +299,7 @@ def classify_species(
     output_path,
     sparse_sampling_step,
     display_names,
-    short_read_mode,
+    validation,
 ):
     """Classify samples using a species model."""
     click.echo("Classifying...")
@@ -311,7 +311,7 @@ def classify_species(
         Path(output_path),
         sparse_sampling_step,
         display_names,
-        short_read_mode,
+        validation,
     )
 
 

--- a/src/xspect/misclassification_detection/mapping.py
+++ b/src/xspect/misclassification_detection/mapping.py
@@ -1,0 +1,154 @@
+"""
+Mapping handler for the alignment-based misclassification detection.
+
+Notes:
+Developed by Oemer Cetin as part of a Bsc thesis at Goethe University Frankfurt am Main (2025).
+(An Integration of Alignment-Free and Alignment-Based Approaches for Bacterial Taxon Assignment)
+"""
+
+import mappy, pysam, os, csv
+from xspect.definitions import fasta_endings
+
+__author__ = "Cetin, Oemer"
+
+
+class MappingHandler:
+    """Handler class for all mapping related procedures."""
+
+    def __init__(self, ref_genome_path: str, reads_path: str) -> None:
+        """
+        Initialise the mapping handler.
+
+        This method sets up the paths to the reference genome and query sequences.
+        Additionally, the paths to the output formats (SAM, BAM and TSV) are generated.
+
+        Args:
+            ref_genome_path (str): The path to the reference genome.
+            reads_path (str): The path to the query sequences.
+        """
+        if not os.path.isfile(ref_genome_path):
+            raise ValueError("The path to the reference genome does not exist.")
+
+        if not os.path.isfile(reads_path):
+            raise ValueError("The path to the reads does not exist.")
+
+        if not ref_genome_path.endswith(tuple(fasta_endings)) and reads_path.endswith(
+            tuple(fasta_endings)
+        ):
+            raise ValueError("The files must be FASTA-files!")
+
+        stem = reads_path.rsplit(".", 1)[0] + "_mapped"
+        self.ref_genome_path = ref_genome_path
+        self.reads_path = reads_path
+        self.sam = stem + ".sam"
+        self.bam = stem + ".sorted.bam"
+        self.tsv = stem + ".start_coordinates.tsv"
+
+    def map_reads_onto_reference(self) -> None:
+        """
+        A Method that maps reads against the respective reference genome.
+
+        This function creates a SAM file via Mappy and converts it into a BAM file.
+        """
+        # create header (entry = sequences of the reference genome)
+        ref_seq = [
+            {"SN": entry.name, "LN": len(entry.sequence)}
+            for entry in pysam.FastxFile(self.ref_genome_path)
+        ]
+        header = {"HD": {"VN": "1.0"}, "SQ": ref_seq}
+        target_id = {sequence["SN"]: number for number, sequence in enumerate(ref_seq)}
+
+        with pysam.FastxFile(self.reads_path) as reads:
+            read_length = len(next(iter(reads)).sequence)
+            preset = "map-ont" if read_length > 150 else "sr"
+        # create SAM-file
+        aln = mappy.Aligner(self.ref_genome_path, preset=preset)
+        with pysam.AlignmentFile(self.sam, "w", header=header) as out:
+            for read in pysam.FastxFile(self.reads_path):
+                read_seq = read.sequence
+                for hit in aln.map(read_seq):
+                    if hit.cigar_str is None:
+                        continue
+                    # add soft-clips so CIGAR length == len(read_seq) IMPORTANT!!
+                    leftS = hit.q_st
+                    rightS = len(read_seq) - hit.q_en
+                    cigar = (
+                        (f"{leftS}S" if leftS > 0 else "")
+                        + hit.cigar_str
+                        + (f"{rightS}S" if rightS > 0 else "")
+                    )
+
+                    mapped_region = pysam.AlignedSegment()
+                    mapped_region.query_name = read.name
+                    mapped_region.query_sequence = read_seq
+                    mapped_region.flag = 16 if hit.strand == -1 else 0
+                    mapped_region.reference_id = target_id[hit.ctg]
+                    mapped_region.reference_start = hit.r_st
+                    mapped_region.mapping_quality = (
+                        hit.mapq or 255
+                    )  # 0-60 (255 means unavailable)
+                    mapped_region.cigarstring = cigar
+                    out.write(mapped_region)
+                    break  # keep only primary
+
+        # create BAM-file
+        pysam.sort("-o", self.bam, self.sam)
+        pysam.index(self.bam)
+
+    def get_total_genome_length(self) -> int:
+        """
+        Get the genome length from a BAM-file.
+
+        This function opens a BAM-file and extracts the genome length information.
+
+        Returns:
+            int: The genome length.
+        """
+        with pysam.AlignmentFile(self.bam, "rb") as bam:
+            return sum(bam.lengths)
+
+    def extract_starting_coordinates(self) -> None:
+        """
+        Extract starting coordinates of mapped regions from a BAM-file.
+
+        This function scans through a BAM-file and creates a TSV-file.
+        The information that is extracted is the starting coordinate for each mapped read.
+        """
+        # create tsv-file with all start positions
+        with pysam.AlignmentFile(self.bam, "rb") as bam, open(self.tsv, "w") as tsv:
+            entry = {i: seq["SN"] for i, seq in enumerate(bam.header.to_dict()["SQ"])}
+            tsv.write("reference_genome\tread\tmapped_starting_coordinate\n")
+            seen = set()
+            for ref_seq in bam.references:
+                for hit in bam.fetch(ref_seq):
+                    if hit.is_unmapped or hit.is_secondary or hit.is_supplementary:
+                        continue
+                    key = (hit.reference_id, hit.reference_start)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    tsv.write(
+                        f"{entry[hit.reference_id]}\t{hit.query_name}\t{hit.reference_start}\n"
+                    )
+
+    def get_start_coordinates(self) -> list[int]:
+        """
+        Get the coordinates of a TSV-file.
+
+        This function opens a TSV-file and saves all starting coordinates in a list.
+
+        Returns:
+            list[int]: The list containing all starting coordinates.
+
+        Raises:
+            ValueError: If no column with starting coordinates is found.
+        """
+        coordinates = []
+        with open(self.tsv, "r", newline="") as f:
+            reader = csv.DictReader(f, delimiter="\t")
+            for row in reader:
+                val = row.get("mapped_starting_coordinate")
+                if val is None:
+                    raise ValueError("Column with starting coordinates not found.")
+                coordinates.append(int(val))
+        return coordinates

--- a/src/xspect/misclassification_detection/point_pattern_analysis.py
+++ b/src/xspect/misclassification_detection/point_pattern_analysis.py
@@ -1,0 +1,102 @@
+"""
+Point pattern density analysis tool for the alignment-based misclassification detection.
+
+Notes:
+Developed by Oemer Cetin as part of Bsc thesis (2025), Goethe University Frankfurt am Main.
+(An Integration of Alignment-Free and Alignment-Based Approaches for Bacterial Taxon Assignment)
+"""
+
+import numpy
+
+__author__ = "Cetin, Oemer"
+
+
+class PointPatternAnalysis:
+    """Class for all point pattern density analysis procedures."""
+
+    def __init__(self, points: list[int], length: int):
+        """
+        Initialise the class for point pattern analysis.
+
+        This method sets up the required list with data points (sorted) and the length of the reference genome.
+        All required intensity for the statistics is also calculated.
+
+        Args:
+            points (list): The start coordinates of mapped regions on the genome.
+            length (int): The length of the reference genome.
+        """
+        if len(points) < 2:
+            raise ValueError("Need at least 2 points.")
+        self.sorted_points = numpy.sort(numpy.asarray(points, dtype=float))
+        self.n = len(points)
+        self.length = float(length)
+
+    def ripleys_k(self) -> tuple[bool, float, float]:
+        """
+        Calculates the K-function for the given point distribution.
+
+        This method calculates the K-function to describe the point distribution.
+        The result is than compared with what would be expected under a completely random distribution.
+        (Under complete randomness the K-function result is 2*r)
+
+        Returns:
+            tuple: A tuple containing the information whether points are clustered or not.
+        """
+        r = 0.01 * self.length
+        left = 0
+        right = 0
+        total_neighbors = 0
+
+        for i in range(self.n):
+            while self.sorted_points[i] - self.sorted_points[left] > r:
+                left += 1
+            if right < i:
+                right = i
+            while (
+                right + 1 < self.n
+                and self.sorted_points[right + 1] - self.sorted_points[i] <= r
+            ):
+                right += 1
+            total_neighbors += right - left
+        k = (self.length / (self.n * (self.n - 1))) * total_neighbors
+        return (k > 2 * r), k, 2 * r
+
+    def ripleys_k_edge_corrected(self) -> tuple[bool, float, float]:
+        """
+        Calculates the K-function for the given point distribution with an edge correction factor.
+
+        This method calculates the K-function to describe the point distribution.
+        This time an additional factor is multiplied for each data point to account for edge effects.
+        The result is than compared with what would be expected under a completely random distribution.
+        (Under complete randomness the K-function result is 2*r)
+
+        Returns:
+            tuple: A tuple containing the information whether the points are clustered or not.
+        """
+        r = 0.01 * self.length
+        left = 0
+        right = 0
+        total_weighted = 0
+
+        for i in range(self.n):
+            while self.sorted_points[i] - self.sorted_points[left] > r:
+                left += 1
+            if right < i:
+                right = i
+            while (
+                right + 1 < self.n
+                and self.sorted_points[right + 1] - self.sorted_points[i] <= r
+            ):
+                right += 1
+
+            neighbors = right - left
+            if neighbors > 0:
+                a = max(0, self.sorted_points[i] - r)
+                b = min(self.length, self.sorted_points[i] + r)
+                overlap = b - a
+                weight = (2 * r) / overlap if overlap > 0 else 0
+
+                total_weighted += weight * neighbors
+
+        k = (self.length / (self.n * (self.n - 1))) * total_weighted
+        return (bool(k > 2 * r)), float(k), 2 * r

--- a/src/xspect/misclassification_detection/simulate_reads.py
+++ b/src/xspect/misclassification_detection/simulate_reads.py
@@ -1,0 +1,55 @@
+"""
+Read simulation for the alignment-based misclassification detection (Used for testing purposes).
+
+Notes:
+Developed by Oemer Cetin as part of a Bsc thesis at Goethe University Frankfurt am Main (2025).
+(An Integration of Alignment-Free and Alignment-Based Approaches for Bacterial Taxon Assignment)
+"""
+
+import random
+from Bio import SeqIO
+
+__author__ = "Cetin, Oemer"
+
+
+def extract_random_reads(
+    fasta_file, output_fasta, read_length=150, num_reads=1000, seed=42
+) -> None:
+    """
+    Uniformly extracts reads from a genome and writes them to a FASTA-file.
+
+    Args:
+        fasta_file (str): Path to input FASTA file.
+        output_fasta (str): Output FASTA file to write simulated reads.
+        read_length (int): Length of each read to extract.
+        num_reads (int): Total number of reads to extract.
+        seed (int): A seed for reproducibility.
+
+    Raises:
+        ValueError: If the sequences are shorter than the chosen read length.
+    """
+    random.seed(seed)
+    sequences = [
+        record
+        for record in SeqIO.parse(fasta_file, "fasta")
+        if len(record.seq) >= read_length
+    ]
+    if not sequences:
+        raise ValueError("No sequences long enough for the desired read length.")
+
+    # Probability to extract reads from large contigs is higher
+    seq_lengths = [len(rec.seq) for rec in sequences]
+    total_length = sum(seq_lengths)
+    weights = [single_length / total_length for single_length in seq_lengths]
+
+    with open(output_fasta, "w") as o:
+        for i in range(num_reads):
+            # random.choices() provides a list!
+            selected = random.choices(sequences, weights=weights, k=1)[0]
+            seq_length = len(selected.seq)
+            start = random.randint(0, seq_length - read_length)
+            read_seq = selected.seq[start : start + read_length]
+            o.write(
+                f">read_{i}_{selected.id}_{start}-{start + read_length}\n{read_seq}\n"
+            )
+    print("The reads have been simulated successfully.")

--- a/src/xspect/models/probabilistic_filter_svm_model.py
+++ b/src/xspect/models/probabilistic_filter_svm_model.py
@@ -184,7 +184,7 @@ class ProbabilisticFilterSVMModel(ProbabilisticFilterModel):
         filter_ids: list[str] = None,
         step: int = 1,
         display_name: bool = False,
-        short_read_mode: bool = False,
+        validation: bool = False,
     ) -> ModelResult:
         """
         Predict the labels of the sequences.
@@ -199,7 +199,7 @@ class ProbabilisticFilterSVMModel(ProbabilisticFilterModel):
             filter_ids (list[str], optional): A list of IDs to filter the predictions.
             step (int, optional): Step size for sparse sampling. Defaults to 1.
             display_name (bool): Includes a display name for each tax_ID.
-            short_read_mode (bool): Sorts out misclassified reads.
+            validation (bool): Sorts out misclassified reads .
 
         Returns:
             ModelResult: The result of the prediction containing hits, number of kmers, and the
@@ -207,7 +207,7 @@ class ProbabilisticFilterSVMModel(ProbabilisticFilterModel):
         """
         # get scores and format them for the SVM
         res = super().predict(
-            sequence_input, filter_ids, step, display_name, short_read_mode
+            sequence_input, filter_ids, step, display_name, validation
         )
         svm_scores = dict(sorted(res.get_scores()["total"].items()))
         svm_scores = [list(svm_scores.values())]

--- a/src/xspect/models/probabilistic_filter_svm_model.py
+++ b/src/xspect/models/probabilistic_filter_svm_model.py
@@ -184,6 +184,7 @@ class ProbabilisticFilterSVMModel(ProbabilisticFilterModel):
         filter_ids: list[str] = None,
         step: int = 1,
         display_name: bool = False,
+        short_read_mode: bool = False,
     ) -> ModelResult:
         """
         Predict the labels of the sequences.
@@ -198,28 +199,27 @@ class ProbabilisticFilterSVMModel(ProbabilisticFilterModel):
             filter_ids (list[str], optional): A list of IDs to filter the predictions.
             step (int, optional): Step size for sparse sampling. Defaults to 1.
             display_name (bool): Includes a display name for each tax_ID.
+            short_read_mode (bool): Sorts out misclassified reads.
 
         Returns:
             ModelResult: The result of the prediction containing hits, number of kmers, and the
             predicted label.
         """
         # get scores and format them for the SVM
-        res = super().predict(sequence_input, filter_ids, step, display_name)
+        res = super().predict(
+            sequence_input, filter_ids, step, display_name, short_read_mode
+        )
         svm_scores = dict(sorted(res.get_scores()["total"].items()))
         svm_scores = [list(svm_scores.values())]
 
         svm = self._get_svm(filter_ids)
-        svm_prediction = str(svm.predict(svm_scores)[0])
-        if display_name:
-            svm_prediction = f"{svm_prediction} -{self.display_names.get(svm_prediction, 'Unknown')}".replace(
-                self.model_display_name, "", 1
-            )
+        res.hits["misclassified"] = res.misclassified
         return ModelResult(
             self.slug(),
             res.hits,
             res.num_kmers,
             sparse_sampling_step=step,
-            prediction=svm_prediction,
+            prediction=str(svm.predict(svm_scores)[0]),
         )
 
     def _get_svm(self, id_keys) -> SVC:

--- a/src/xspect/models/result.py
+++ b/src/xspect/models/result.py
@@ -40,6 +40,7 @@ class ModelResult:
         self.sparse_sampling_step = sparse_sampling_step
         self.prediction = prediction
         self.input_source = input_source
+        self.misclassified = self.hits.pop("misclassified", None)
 
     def get_scores(self) -> dict:
         """
@@ -165,6 +166,7 @@ class ModelResult:
             "hits": self.hits,
             "scores": self.get_scores(),
             "num_kmers": self.num_kmers,
+            "misclassified": self.misclassified,
             "input_source": self.input_source,
         }
 

--- a/src/xspect/ncbi.py
+++ b/src/xspect/ncbi.py
@@ -345,7 +345,9 @@ class NCBIHandler:
                 if file.endswith(".fna"):
                     extracted_path = zip_ref.extract(file, path=output_dir)
                     fna_file = output_dir / f"{taxon_id}.fna"
-                    Path(extracted_path).rename(fna_file) # consistent file name (tax_id)
+                    Path(extracted_path).rename(
+                        fna_file
+                    )  # consistent file name (tax_id)
                     logger.info(f"Extracted reference genome to {fna_file}")
                     break
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,7 +119,9 @@ def test_classify_species_with_names(
 
     with open(str(tmpdir) + "/classify_species_with_names.json", encoding="utf-8") as f:
         result_content = json.load(f)
-        assert result_content["prediction"] == species_display_name
+        assert (
+            result_content["prediction"] == species_display_name.split("-")[0].strip()
+        )
         for subseq_scores in result_content["scores"].values():
             assert species_display_name in subseq_scores
         for subseq_hits in result_content["hits"].values():

--- a/tests/test_misclassification_detection.py
+++ b/tests/test_misclassification_detection.py
@@ -1,0 +1,93 @@
+"""Test the detection of misclassified sequences."""
+
+from xspect.misclassification_detection.mapping import MappingHandler
+from xspect.misclassification_detection.simulate_reads import extract_random_reads
+from xspect.ncbi import NCBIHandler
+import pytest, os
+
+from xspect.misclassification_detection.point_pattern_analysis import (
+    PointPatternAnalysis,
+)
+
+
+@pytest.fixture(scope="module")
+def ncbi_handler():
+    """Fixture for the NCBI class."""
+    ncbi_api_key = os.environ.get("NCBI_API_KEY")
+    return NCBIHandler(api_key=ncbi_api_key)
+
+
+@pytest.fixture()
+def reference(ncbi_handler, tmp_path):
+    """Fixture for the path to the genome."""
+    path = ncbi_handler.download_reference_genome(470, tmp_path)
+    read_path = tmp_path / "reads.fasta"
+    extract_random_reads(str(path), str(read_path), 150, 1000)
+    # read_path = tmp_path / "reads.fasta"
+    return path, read_path
+
+
+@pytest.fixture()
+def mapping_handler(reference):
+    """Fixture for the path to the genome."""
+    handler = MappingHandler(str(reference[0]), str(reference[1]))
+    return handler
+
+
+def test_extract_random_reads(reference, tmp_path):
+    """Test the read simulation."""
+    read_path = tmp_path / "read.fasta"
+    extract_random_reads(str(reference[0]), str(read_path), 150, 10)
+    assert read_path.exists()
+
+
+def test_mapping_procedure(reference, mapping_handler):
+    """Test the read simulation."""
+    assert not os.path.isfile(mapping_handler.bam)
+    mapping_handler.map_reads_onto_reference()
+    mapping_handler.extract_starting_coordinates()
+    genome_length = mapping_handler.get_total_genome_length()
+    start_coordinates = mapping_handler.get_start_coordinates()
+    assert genome_length > 3000000
+    assert os.path.isfile(mapping_handler.bam)
+    assert os.path.isfile(mapping_handler.tsv)
+    assert len(start_coordinates) > 0
+
+
+def test_point_pattern_analysis():
+    """Test the point pattern density functions."""
+    genome_length = 400000
+    first_point_list = [  # Not clustered
+        500,
+        5000,
+        10000,
+        30000,
+        80000,
+        100000,
+        104000,
+        170000,
+        200000,
+        300000,
+        399999,
+    ]
+    first_analysis = PointPatternAnalysis(first_point_list, genome_length)
+
+    second_point_list = [  # clustered
+        500,
+        5000,
+        10000,
+        81000,
+        81500,
+        82000,
+        84000,
+        200000,
+        300000,
+        399999,
+    ]
+    second_analysis = PointPatternAnalysis(second_point_list, genome_length)
+
+    assert first_analysis.ripleys_k()[0] == False
+    assert first_analysis.ripleys_k_edge_corrected()[0] == False
+
+    assert second_analysis.ripleys_k()[0] == True
+    assert second_analysis.ripleys_k_edge_corrected()[0] == True

--- a/tests/test_ncbi.py
+++ b/tests/test_ncbi.py
@@ -50,7 +50,7 @@ def test_get_species(ncbi_handler):
     species_ids = ncbi_handler.get_species(genus_id)
     assert isinstance(species_ids, list)
     assert len(species_ids) > 0
-    assert 470 in species_ids
+    assert 40216 in species_ids  # radioresistens
 
 
 def test_get_taxon_names(ncbi_handler):
@@ -96,3 +96,11 @@ def test_download_assemblies(ncbi_handler, tmp_path):
     downloaded_file = tmp_path / "ncbi_dataset.zip"
     assert downloaded_file.is_file()
     assert downloaded_file.stat().st_size > 0
+
+
+def test_download_reference_genome(ncbi_handler, tmp_path):
+    """Test the download_assemblies method of the NCBI class."""
+    tax_id = 470
+    file_path = ncbi_handler.download_reference_genome(tax_id, tmp_path)
+
+    assert file_path.is_file()


### PR DESCRIPTION
The added feature is an integration of an alignment-based post processing strategy that detects misclassified reads.
Strategy:
1. Group sequences by taxonomy_ID (species) with highest score
2. Map all reads of a species group against the reference genome
3. Extract start positions of mapped regions
4. Local cluster detection via Ripley's K-function
5. Sort out reads if they are clustered on the reference genome.

The feature is accesed with the classify species command by specifying the flag -r.